### PR TITLE
Fix audio playback in Qt GUI

### DIFF
--- a/qt_ios_line_cast_screen/src/SoundPlay.cpp
+++ b/qt_ios_line_cast_screen/src/SoundPlay.cpp
@@ -31,18 +31,20 @@ void SoundPlay::PauseAudioDevice(int nPauseOn)
 
 bool SoundPlay::SetFormat(int nChannels, int nSamplerate)
 {
+	SDL_zero(m_AudioSpec);
 	m_AudioSpec.freq		= nSamplerate;
 	m_AudioSpec.format		= AUDIO_S16SYS;
 	m_AudioSpec.channels	= nChannels;
-	m_AudioSpec.samples		= 1024;
-	m_AudioSpec.silence		= 0;
+	m_AudioSpec.samples		= 4096;
+	//m_AudioSpec.silence		= 0;
 	m_AudioSpec.callback	= nullptr;
 
-	m_AudioDeviceID = SDL_OpenAudioDevice(nullptr, 0, &m_AudioSpec, nullptr, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+	m_AudioDeviceID = SDL_OpenAudioDevice(nullptr, 0, &m_AudioSpec, nullptr, 0);
 	if (m_AudioDeviceID < 2)
 	{
 		return false;
 	}
+	SDL_PauseAudioDevice(m_AudioDeviceID, 0);
 	return true;
 }
 

--- a/qt_ios_line_cast_screen/src/airplaysource.cpp
+++ b/qt_ios_line_cast_screen/src/airplaysource.cpp
@@ -44,6 +44,7 @@ AirPlaySource::AirPlaySource(QWidget *parent) : QWidget(parent)
 
     m_pSoundPlay = new SoundPlay;
     m_pSoundPlay->Init();
+	m_pSoundPlay->SetFormat(2, 48000);
 }
 
 AirPlaySource::~AirPlaySource()
@@ -132,10 +133,10 @@ void AirPlaySource::audio_process(void* user_data, unsigned char* buffer, int le
 //        printf("user_data[%u|%s] %s: %d\n", user_data->device_index, user_data->serial_number, __FUNCTION__, length);
     AirPlaySource* m_AirPlaySource = (AirPlaySource*)user_data;
 
-    if (g_pVideoWindow->GetFullWindowSource() == m_AirPlaySource)
-    {
-        m_AirPlaySource->m_pSoundPlay->PushData(buffer, length);
-    }
+    //if (g_pVideoWindow->GetFullWindowSource() == m_AirPlaySource)
+    //{
+    m_AirPlaySource->m_pSoundPlay->PushData(buffer, length);
+    //}
     m_AirPlaySource->m_pSoundPlay->PauseAudioDevice(0);
 }
 


### PR DESCRIPTION
## Description
This PR fixes the missing audio playback issue in the `qt_ios_line_cast_screen` example. The audio stream from the iOS device was previously ignored or silently dropped by SDL.

## Changes
### `airplaysource.cpp`
- **Audio Initialization**: Added `m_pSoundPlay->SetFormat(2, 48000);` in the constructor to ensure the player knows the expected stream format.
- **Callback Fix**: Commented out the restrictive `GetFullWindowSource()` check in `audio_process`. The audio buffer is now properly pushed to `m_pSoundPlay` in all cases.

### `SoundPlay.cpp`
- **SDL Initialization**: Added `SDL_zero(m_AudioSpec);` and commented out manual silence assignment to prevent memory garbage during setup.
- **Buffer Size**: Increased `m_AudioSpec.samples` from `1024` to `4096` to prevent potential audio dropouts.
- **Strict Format**: Forced strict format matching in `SDL_OpenAudioDevice` (flag set to `0`).
- **Unpause Device**: Added `SDL_PauseAudioDevice(m_AudioDeviceID, 0);` at the end of the setup. *SDL starts audio devices in a paused state by default, which caused the playback to be completely silent.*